### PR TITLE
Fix audio clipping in regular dfpwm transcoding

### DIFF
--- a/QuartzEncoder/AudioEncoder.cs
+++ b/QuartzEncoder/AudioEncoder.cs
@@ -132,7 +132,7 @@ public class AudioEncoder
                 o.WithAudioSamplingRate(48000);
                 o.WithAudioBitrate(48);
                 o.ForceFormat("dfpwm");
-                o.WithCustomArgument("-af \"pan=mono|c0=c0+c1\"");
+                o.WithCustomArgument("-ac 1");
             })
             .ProcessAsynchronously();
 


### PR DESCRIPTION
This fixes audio clipping when encoding regular dfpwm. It will still merge the channels, but not by adding them, increasing clipping